### PR TITLE
Fixing the "Add an element to the end of a list" example

### DIFF
--- a/static/posts/2011-03-02-updating-rdf-lists-with-sparql.html
+++ b/static/posts/2011-03-02-updating-rdf-lists-with-sparql.html
@@ -153,9 +153,17 @@ INSERT { ?elt rdf:rest [ rdf:first 98 ; rdf:rest rdf:nil ] }
 WHERE
 {
   ?x :p ?list .
-  # List of length >= 1
-  ?list rdf:rest+ ?elt .
-  ?elt rdf:rest rdf:nil .
+  # List of length = 1
+  {
+    ?list rdf:rest rdf:nil .
+    BIND (?list AS ?elt)
+  }
+  UNION
+  # List of length > 1
+  {
+    ?list rdf:rest+ ?elt .
+    ?elt rdf:rest rdf:nil .
+  }
   # ?elt is last cons cell
 } ;
 


### PR DESCRIPTION
For lists of length 1. Problem description: https://lists.w3.org/Archives/Public/public-sparql-dev/2022JanMar/0009.html
Note that I haven't checked the other examples.